### PR TITLE
Add additional type exports

### DIFF
--- a/draft-06/index.d.ts
+++ b/draft-06/index.d.ts
@@ -2,9 +2,10 @@ import type { Json } from "@hyperjump/json-pointer";
 import type { JsonSchemaType } from "../lib/common.js";
 
 
-export type JsonSchemaDraft06 = boolean | {
+export type JsonSchemaDraft06Ref = {
   $ref: string;
-} | {
+};
+export type JsonSchemaDraft06Object = {
   $schema?: "http://json-schema.org/draft-06/schema#";
   $id?: string;
   title?: string;
@@ -43,5 +44,6 @@ export type JsonSchemaDraft06 = boolean | {
   oneOf?: JsonSchemaDraft06[];
   not?: JsonSchemaDraft06;
 };
+export type JsonSchemaDraft06 = boolean | JsonSchemaDraft06Ref | JsonSchemaDraft06Object;
 
 export * from "../lib/index.js";

--- a/draft-2019-09/index.d.ts
+++ b/draft-2019-09/index.d.ts
@@ -2,7 +2,7 @@ import type { Json } from "@hyperjump/json-pointer";
 import type { JsonSchemaType } from "../lib/common.js";
 
 
-export type JsonSchemaDraft201909 = boolean | {
+export type JsonSchemaDraft201909Object = {
   $schema?: "https://json-schema.org/draft/2019-09/schema";
   $id?: string;
   $anchor?: string;
@@ -61,5 +61,6 @@ export type JsonSchemaDraft201909 = boolean | {
   contentEncoding?: string;
   contentSchema?: JsonSchemaDraft201909;
 };
+export type JsonSchemaDraft201909 = boolean | JsonSchemaDraft201909Object;
 
 export * from "../lib/index.js";

--- a/draft-2020-12/index.d.ts
+++ b/draft-2020-12/index.d.ts
@@ -2,7 +2,7 @@ import type { Json } from "@hyperjump/json-pointer";
 import type { JsonSchemaType } from "../lib/common.js";
 
 
-export type JsonSchemaDraft202012 = boolean | {
+export type JsonSchemaDraft202012Object = {
   $schema?: "https://json-schema.org/draft/2020-12/schema";
   $id?: string;
   $anchor?: string;
@@ -62,5 +62,6 @@ export type JsonSchemaDraft202012 = boolean | {
   contentEncoding?: string;
   contentSchema?: JsonSchemaDraft202012;
 };
+export type JsonSchemaDraft202012 = boolean | JsonSchemaDraft202012Object;
 
 export * from "../lib/index.js";

--- a/stable/index.d.ts
+++ b/stable/index.d.ts
@@ -2,6 +2,8 @@ import type { Json } from "@hyperjump/json-pointer";
 import type { JsonSchemaType } from "../lib/common.js";
 
 
+export type JsonSchemaType = JsonSchemaType;
+
 export type JsonSchema = boolean | {
   $schema?: "https://json-schema.org/validation";
   $id?: string;


### PR DESCRIPTION
I want to use Hyperjump in my own TypeScript code without needing to redefine existing types.
In some cases, I know my schema is an object, so having that as a separate type is incredibly helpful.
Also making use of the enum of types is really helpful.
