### PR TITLE
fix: Remove 'VERBOSE' from OutputFormat type in outdated type definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -48,7 +48,7 @@ export type OutputUnit = {
 
 export const FLAG: "FLAG";
 
-export type OutputFormat = "FLAG" | "BASIC" | "DETAILED" | "VERBOSE";
+export type OutputFormat = "FLAG" | "BASIC" | "DETAILED";
 
 export const setMetaSchemaOutputFormat: (format: OutputFormat) => void;
 export const getMetaSchemaOutputFormat: () => OutputFormat;


### PR DESCRIPTION
fixes #88 