### PR TITLE
fix typo: Rename 'additionOperations' to 'additionalOperations' and `mappings` to `mapping`

### DIFF
--- a/openapi-3-2/index.d.ts
+++ b/openapi-3-2/index.d.ts
@@ -69,7 +69,7 @@ export type OasSchema32 = boolean | {
 
 type Discriminator = {
   propertyName: string;
-  mappings?: Record<string, string>;
+  mapping?: Record<string, string>;
   defaultMapping?: string;
 };
 


### PR DESCRIPTION
Just some typo fixes according to https://spec.openapis.org/oas/latest.html#discriminator-object and https://spec.openapis.org/oas/latest.html#path-item-object