### PR TITLE
Fix: `allowEmptyValue` is valid only for query parameters.

### DIFF
--- a/openapi-3-2/index.d.ts
+++ b/openapi-3-2/index.d.ts
@@ -188,7 +188,6 @@ export type Parameter = {
   description?: string;
   required?: boolean;
   deprecated?: boolean;
-  allowEmptyValue?: boolean;
 } & Examples & (
   (
     {
@@ -201,6 +200,7 @@ export type Parameter = {
   ) | (
     {
       in: "query";
+      allowEmptyValue?: boolean;
     } & (
       ({ style?: "form" | "spaceDelimited" | "pipeDelimited" | "deepObject" } & SchemaParameter)
       | ContentParameter


### PR DESCRIPTION
According to: https://spec.openapis.org/oas/latest.html#common-fixed-fields

<img width="832" height="280" alt="image" src="https://github.com/user-attachments/assets/ada5d108-e1d3-49b6-809a-cf7df001c87c" />
