### PR TITLE
fix: bundle test-utils uses entry.path causing ENOENT on Windows; should use entry.parentPath

### DIFF
--- a/bundle/test-utils.js
+++ b/bundle/test-utils.js
@@ -65,9 +65,9 @@ const fixtures = {};
 readdirSync("bundle/fixtures", { withFileTypes: true, recursive: true })
   .filter((entry) => entry.isFile() && entry.name.endsWith(".schema.json"))
   .forEach((entry) => {
-    const path = relative("bundle/fixtures", `${entry.path}/${basename(entry.name, ".schema.json")}`);
+    const path = relative("bundle/fixtures", `${entry.parentPath}/${basename(entry.name, ".schema.json")}`);
     const retrievalUri = `https://bundler.hyperjump.io/${path}`;
-    const fixture = JSON.parse(readFileSync(`${entry.path}/${entry.name}`, "utf8"));
+    const fixture = JSON.parse(readFileSync(`${entry.parentPath}/${entry.name}`, "utf8"));
     fixtures[retrievalUri] = fixture;
   });
 


### PR DESCRIPTION
Problem: The bundler fixtures loader uses `entry.path` from `fs.readdirSync({ withFileTypes: true, recursive: true })`. 
On Windows, Dirent.path can be undefined, so npm test fails with ENOENT

Fix: In test-utils.js , replace entry.path with entry.parentPath for path building and readFileSync. This matches existing usage in `v1/json-schema-test-suite.spec.ts` and works cross‑platform.

Linux/WSL note: Dirent.path is often defined there, so the bug is masked; parentPath avoids the platform-dependent behavior.