### PR TITLE
feat(openapi): export all oas types

### DIFF
--- a/openapi-3-0/index.d.ts
+++ b/openapi-3-0/index.d.ts
@@ -39,17 +39,17 @@ export type OasSchema30 = {
   xml?: Xml;
 };
 
-type Discriminator = {
+export type Discriminator = {
   propertyName: string;
   mappings?: Record<string, string>;
 };
 
-type ExternalDocs = {
+export type ExternalDocs = {
   url: string;
   description?: string;
 };
 
-type Xml = {
+export type Xml = {
   name?: string;
   namespace?: string;
   prefix?: string;
@@ -68,11 +68,11 @@ export type OpenApi30 = {
   components?: Components;
 };
 
-type Reference = {
+export type Reference = {
   $ref: "string";
 };
 
-type Info = {
+export type Info = {
   title: string;
   description?: string;
   termsOfService?: string;
@@ -81,30 +81,30 @@ type Info = {
   version: string;
 };
 
-type Contact = {
+export type Contact = {
   name?: string;
   url?: string;
   email?: string;
 };
 
-type License = {
+export type License = {
   name: string;
   url?: string;
 };
 
-type Server = {
+export type Server = {
   url: string;
   description?: string;
   variables?: Record<string, ServerVariable>;
 };
 
-type ServerVariable = {
+export type ServerVariable = {
   enum?: string[];
   default: string;
   description?: string;
 };
 
-type Components = {
+export type Components = {
   schemas?: Record<string, OasSchema30>;
   responses?: Record<string, Response | Reference>;
   parameters?: Record<string, Parameter | Reference>;
@@ -116,28 +116,28 @@ type Components = {
   callbacks: Record<string, Callback | Reference>;
 };
 
-type Response = {
+export type Response = {
   description: string;
   headers?: Record<string, Header | Reference>;
   content?: Record<string, MediaType>;
   links?: Record<string, Link | Reference>;
 };
 
-type MediaType = {
+export type MediaType = {
   schema?: OasSchema30;
   example?: unknown;
   examples?: Record<string, Example | Reference>;
   encoding?: Record<string, Encoding>;
 };
 
-type Example = {
+export type Example = {
   summary?: string;
   description?: string;
   value?: unknown;
   externalValue?: string;
 };
 
-type Header = {
+export type Header = {
   description?: string;
   required?: boolean;
   deprecated?: boolean;
@@ -151,9 +151,9 @@ type Header = {
   examples: Record<string, Example | Reference>;
 };
 
-type Paths = Record<string, PathItem>;
+export type Paths = Record<string, PathItem>;
 
-type PathItem = {
+export type PathItem = {
   $ref?: string;
   summary?: string;
   description?: string;
@@ -169,7 +169,7 @@ type PathItem = {
   trace?: Operation;
 };
 
-type Operation = {
+export type Operation = {
   tags?: string[];
   summary?: string;
   description?: string;
@@ -184,17 +184,17 @@ type Operation = {
   servers?: Server[];
 };
 
-type Responses = Record<string, Response | Reference>;
+export type Responses = Record<string, Response | Reference>;
 
-type SecurityRequirement = Record<string, string[]>;
+export type SecurityRequirement = Record<string, string[]>;
 
-type Tag = {
+export type Tag = {
   name: string;
   description?: string;
   externalDocs?: ExternalDocs;
 };
 
-type Parameter = {
+export type Parameter = {
   name: string;
   in: string;
   description?: string;
@@ -210,73 +210,73 @@ type Parameter = {
   examples?: Record<string, Example | Reference>;
 };
 
-type RequestBody = {
+export type RequestBody = {
   description?: string;
   content: Record<string, MediaType>;
   required?: boolean;
 };
 
-type SecurityScheme = APIKeySecurityScheme | HTTPSecurityScheme | OAuth2SecurityScheme | OpenIdConnectSecurityScheme;
+export type SecurityScheme = APIKeySecurityScheme | HTTPSecurityScheme | OAuth2SecurityScheme | OpenIdConnectSecurityScheme;
 
-type APIKeySecurityScheme = {
+export type APIKeySecurityScheme = {
   type: "apiKey";
   name: string;
   in: "header" | "query" | "cookie";
   description?: string;
 };
 
-type HTTPSecurityScheme = {
+export type HTTPSecurityScheme = {
   scheme: string;
   bearerFormat?: string;
   description?: string;
   type: "http";
 };
 
-type OAuth2SecurityScheme = {
+export type OAuth2SecurityScheme = {
   type: "oauth2";
   flows: OAuthFlows;
   description?: string;
 };
 
-type OpenIdConnectSecurityScheme = {
+export type OpenIdConnectSecurityScheme = {
   type: "openIdConnect";
   openIdConnectUrl: string;
   description?: string;
 };
 
-type OAuthFlows = {
+export type OAuthFlows = {
   implicit?: ImplicitOAuthFlow;
   password?: PasswordOAuthFlow;
   clientCredentials?: ClientCredentialsFlow;
   authorizationCode?: AuthorizationCodeOAuthFlow;
 };
 
-type ImplicitOAuthFlow = {
+export type ImplicitOAuthFlow = {
   authorizationUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type PasswordOAuthFlow = {
+export type PasswordOAuthFlow = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type ClientCredentialsFlow = {
+export type ClientCredentialsFlow = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type AuthorizationCodeOAuthFlow = {
+export type AuthorizationCodeOAuthFlow = {
   authorizationUrl: string;
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type Link = {
+export type Link = {
   operationId?: string;
   operationRef?: string;
   parameters?: Record<string, unknown>;
@@ -285,9 +285,9 @@ type Link = {
   server?: Server;
 };
 
-type Callback = Record<string, PathItem>;
+export type Callback = Record<string, PathItem>;
 
-type Encoding = {
+export type Encoding = {
   contentType?: string;
   headers?: Record<string, Header | Reference>;
   style?: "form" | "spaceDelimited" | "pipeDelimited" | "deepObject";

--- a/openapi-3-1/index.d.ts
+++ b/openapi-3-1/index.d.ts
@@ -67,17 +67,17 @@ export type OasSchema31 = boolean | {
   xml?: Xml;
 };
 
-type Discriminator = {
+export type Discriminator = {
   propertyName: string;
   mappings?: Record<string, string>;
 };
 
-type ExternalDocs = {
+export type ExternalDocs = {
   url: string;
   description?: string;
 };
 
-type Xml = {
+export type Xml = {
   name?: string;
   namespace?: string;
   prefix?: string;
@@ -98,7 +98,7 @@ export type OpenApi = {
   components?: Components;
 };
 
-type Info = {
+export type Info = {
   title: string;
   summary?: string;
   description?: string;
@@ -108,31 +108,31 @@ type Info = {
   version: string;
 };
 
-type Contact = {
+export type Contact = {
   name?: string;
   url?: string;
   email?: string;
 };
 
-type License = {
+export type License = {
   name: string;
   url?: string;
   identifier?: string;
 };
 
-type Server = {
+export type Server = {
   url: string;
   description?: string;
   variables?: Record<string, ServerVariable>;
 };
 
-type ServerVariable = {
+export type ServerVariable = {
   enum?: string[];
   default: string;
   description?: string;
 };
 
-type Components = {
+export type Components = {
   schemas?: Record<string, OasSchema31>;
   responses?: Record<string, Response | Reference>;
   parameters?: Record<string, Parameter | Reference>;
@@ -145,7 +145,7 @@ type Components = {
   pathItems?: Record<string, PathItem | Reference>;
 };
 
-type PathItem = {
+export type PathItem = {
   summary?: string;
   description?: string;
   servers?: Server[];
@@ -160,7 +160,7 @@ type PathItem = {
   trace?: Operation;
 };
 
-type Operation = {
+export type Operation = {
   tags?: string[];
   summary?: string;
   description?: string;
@@ -175,7 +175,7 @@ type Operation = {
   servers?: Server[];
 };
 
-type ExternalDocumentation = {
+export type ExternalDocumentation = {
   description?: string;
   url: string;
 };
@@ -219,32 +219,32 @@ export type Parameter = {
   )
 );
 
-type ContentParameter = {
+export type ContentParameter = {
   schema?: never;
   content: Record<string, MediaType | Reference>;
 };
 
-type SchemaParameter = {
+export type SchemaParameter = {
   explode?: boolean;
   allowReserved?: boolean;
   schema: OasSchema32;
   content?: never;
 } & Examples;
 
-type RequestBody = {
+export type RequestBody = {
   description?: string;
   content: Content;
   required?: boolean;
 };
 
-type Content = Record<string, MediaType>;
+export type Content = Record<string, MediaType>;
 
-type MediaType = {
+export type MediaType = {
   schema?: OasSchema31;
   encoding?: Record<string, Encoding>;
 } & Examples;
 
-type Encoding = {
+export type Encoding = {
   contentType?: string;
   headers?: Record<string, Header | Reference>;
   style?: "form" | "spaceDelimited" | "pipeDelimited" | "deepObject";
@@ -252,23 +252,23 @@ type Encoding = {
   allowReserved?: boolean;
 };
 
-type Response = {
+export type Response = {
   description: string;
   headers?: Record<string, Header | Reference>;
   content?: Content;
   links?: Record<string, Link | Reference>;
 };
 
-type Callback = Record<string, PathItem>;
+export type Callback = Record<string, PathItem>;
 
-type Example = {
+export type Example = {
   summary?: string;
   description?: string;
   value?: Json;
   externalValue?: string;
 };
 
-type Link = {
+export type Link = {
   operationRef?: string;
   operationId?: string;
   parameters?: Record<string, string>;
@@ -277,7 +277,7 @@ type Link = {
   server?: Server;
 };
 
-type Header = {
+export type Header = {
   description?: string;
   required?: boolean;
   deprecated?: boolean;
@@ -287,19 +287,19 @@ type Header = {
   content?: Content;
 };
 
-type Tag = {
+export type Tag = {
   name: string;
   description?: string;
   externalDocs?: ExternalDocumentation;
 };
 
-type Reference = {
+export type Reference = {
   $ref: string;
   summary?: string;
   description?: string;
 };
 
-type SecurityScheme = {
+export type SecurityScheme = {
   type: "apiKey";
   description?: string;
   name: string;
@@ -322,41 +322,41 @@ type SecurityScheme = {
   openIdConnectUrl: string;
 };
 
-type OauthFlows = {
+export type OauthFlows = {
   implicit?: Implicit;
   password?: Password;
   clientCredentials?: ClientCredentials;
   authorizationCode?: AuthorizationCode;
 };
 
-type Implicit = {
+export type Implicit = {
   authorizationUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type Password = {
+export type Password = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type ClientCredentials = {
+export type ClientCredentials = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type AuthorizationCode = {
+export type AuthorizationCode = {
   authorizationUrl: string;
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type SecurityRequirement = Record<string, string[]>;
+export type SecurityRequirement = Record<string, string[]>;
 
-type Examples = {
+export type Examples = {
   example?: Json;
   examples?: Record<string, Example | Reference>;
 };

--- a/openapi-3-2/index.d.ts
+++ b/openapi-3-2/index.d.ts
@@ -67,18 +67,18 @@ export type OasSchema32 = boolean | {
   xml?: Xml;
 };
 
-type Discriminator = {
+export type Discriminator = {
   propertyName: string;
   mapping?: Record<string, string>;
   defaultMapping?: string;
 };
 
-type ExternalDocs = {
+export type ExternalDocs = {
   url: string;
   description?: string;
 };
 
-type Xml = {
+export type Xml = {
   nodeType?: "element" | "attribute" | "text" | "cdata" | "none";
   name?: string;
   namespace?: string;
@@ -101,7 +101,7 @@ export type OpenApi = {
   externalDocs?: ExternalDocs;
 };
 
-type Info = {
+export type Info = {
   title: string;
   summary?: string;
   description?: string;
@@ -111,32 +111,32 @@ type Info = {
   version: string;
 };
 
-type Contact = {
+export type Contact = {
   name?: string;
   url?: string;
   email?: string;
 };
 
-type License = {
+export type License = {
   name: string;
   identifier?: string;
   url?: string;
 };
 
-type Server = {
+export type Server = {
   url: string;
   description?: string;
   name?: string;
   variables?: Record<string, ServerVariable>;
 };
 
-type ServerVariable = {
+export type ServerVariable = {
   enum?: string[];
   default: string;
   description?: string;
 };
 
-type Components = {
+export type Components = {
   schemas?: Record<string, OasSchema32>;
   responses?: Record<string, Response | Reference>;
   parameters?: Record<string, Parameter | Reference>;
@@ -150,7 +150,7 @@ type Components = {
   mediaTypes?: Record<string, MediaType | Reference>;
 };
 
-type PathItem = {
+export type PathItem = {
   $ref?: string;
   summary?: string;
   description?: string;
@@ -168,7 +168,7 @@ type PathItem = {
   parameters?: (Parameter | Reference)[];
 };
 
-type Operation = {
+export type Operation = {
   tags?: string[];
   summary?: string;
   description?: string;
@@ -224,25 +224,25 @@ export type Parameter = {
   )
 );
 
-type ContentParameter = {
+export type ContentParameter = {
   schema?: never;
   content: Record<string, MediaType | Reference>;
 };
 
-type SchemaParameter = {
+export type SchemaParameter = {
   explode?: boolean;
   allowReserved?: boolean;
   schema: OasSchema32;
   content?: never;
 };
 
-type RequestBody = {
+export type RequestBody = {
   description?: string;
   content: Record<string, MediaType | Reference>;
   required?: boolean;
 };
 
-type MediaType = {
+export type MediaType = {
   schema?: OasSchema32;
   itemSchema?: OasSchema32;
 } & Examples & ({
@@ -255,7 +255,7 @@ type MediaType = {
   itemEncoding?: Encoding;
 });
 
-type Encoding = {
+export type Encoding = {
   contentType?: string;
   headers?: Record<string, Header | Reference>;
   style?: "form" | "spaceDelimited" | "pipeDelimited" | "deepObject";
@@ -271,11 +271,11 @@ type Encoding = {
   itemEncoding?: Encoding;
 });
 
-type Responses = {
+export type Responses = {
   default?: Response | Reference;
 } & Record<string, Response | Reference>;
 
-type Response = {
+export type Response = {
   summary?: string;
   description?: string;
   headers?: Record<string, Header | Reference>;
@@ -283,14 +283,14 @@ type Response = {
   links?: Record<string, Link | Reference>;
 };
 
-type Callback = Record<string, PathItem>;
+export type Callback = Record<string, PathItem>;
 
-type Examples = {
+export type Examples = {
   example?: Json;
   examples?: Record<string, Example | Reference>;
 };
 
-type Example = {
+export type Example = {
   summary?: string;
   description?: string;
 } & ({
@@ -305,7 +305,7 @@ type Example = {
   externalValue?: string;
 });
 
-type Link = {
+export type Link = {
   operationRef?: string;
   operationId?: string;
   parameters?: Record<string, string>;
@@ -314,7 +314,7 @@ type Link = {
   server?: Server;
 };
 
-type Header = {
+export type Header = {
   description?: string;
   required?: boolean;
   deprecated?: boolean;
@@ -326,7 +326,7 @@ type Header = {
   content: Record<string, MediaType | Reference>;
 });
 
-type Tag = {
+export type Tag = {
   name: string;
   summary?: string;
   description?: string;
@@ -335,13 +335,13 @@ type Tag = {
   kind?: string;
 };
 
-type Reference = {
+export type Reference = {
   $ref: string;
   summary?: string;
   description?: string;
 };
 
-type SecurityScheme = {
+export type SecurityScheme = {
   type: "apiKey";
   description?: string;
   name: string;
@@ -370,7 +370,7 @@ type SecurityScheme = {
   deprecated?: boolean;
 };
 
-type OauthFlows = {
+export type OauthFlows = {
   implicit?: Implicit;
   password?: Password;
   clientCredentials?: ClientCredentials;
@@ -378,38 +378,38 @@ type OauthFlows = {
   deviceAuthorization?: DeviceAuthorization;
 };
 
-type Implicit = {
+export type Implicit = {
   authorizationUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type Password = {
+export type Password = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type ClientCredentials = {
+export type ClientCredentials = {
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type AuthorizationCode = {
+export type AuthorizationCode = {
   authorizationUrl: string;
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type DeviceAuthorization = {
+export type DeviceAuthorization = {
   deviceAuthorizationUrl: string;
   tokenUrl: string;
   refreshUrl?: string;
   scopes: Record<string, string>;
 };
 
-type SecurityRequirement = Record<string, string[]>;
+export type SecurityRequirement = Record<string, string[]>;
 
 export * from "../lib/index.js";


### PR DESCRIPTION
I'm working on a project where I need to pass around parts of an OpenAPI spec a lot, and either need
to redefine these types or duplicate a lot of logic working from the top-level `OpenApi` object
when, for instance, I'm only interested in a single PathItem.

Exporting these would be useful for these types of situations, and since they adhere to and are
versioned according to the OAS, not to mention indirectly exposed through the OpenApi type, I
imagine these are fairly unlikely to see breaking changes.
