### PR TITLE
fix: correct “constraint” and “intended” typos

### DIFF
--- a/annotations/test-utils.js
+++ b/annotations/test-utils.js
@@ -30,7 +30,7 @@ export const isCompatible = (compatibility, versionUnderTest) => {
         }
         break;
       default:
-        throw Error(`Unsupported contraint operator: ${operator}`);
+        throw Error(`Unsupported constraint operator: ${operator}`);
     }
   }
 

--- a/bundle/test-utils.js
+++ b/bundle/test-utils.js
@@ -54,7 +54,7 @@ export const isCompatible = (compatibility, versionUnderTest) => {
         }
         break;
       default:
-        throw Error(`Unsupported contraint operator: ${operator}`);
+        throw Error(`Unsupported constraint operator: ${operator}`);
     }
   }
 

--- a/draft-2019-09/json-schema-test-suite.spec.ts
+++ b/draft-2019-09/json-schema-test-suite.spec.ts
@@ -19,7 +19,7 @@ type Test = {
   valid: boolean;
 };
 
-// This package is indended to be a compatibility mode from v1 JSON Schema.
+// This package is intended to be a compatibility mode from v1 JSON Schema.
 // Some edge cases might not work exactly as specified, but it should work for
 // any real-life schema.
 const skip = new Set<string>([

--- a/draft-2020-12/json-schema-test-suite.spec.ts
+++ b/draft-2020-12/json-schema-test-suite.spec.ts
@@ -19,7 +19,7 @@ type Test = {
   valid: boolean;
 };
 
-// This package is indended to be a compatibility mode from v1 JSON Schema.
+// This package is intended to be a compatibility mode from v1 JSON Schema.
 // Some edge cases might not work exactly as specified, but it should work for
 // any real-life schema.
 const skip = new Set<string>([

--- a/openapi-3-0/json-schema-test-suite.spec.ts
+++ b/openapi-3-0/json-schema-test-suite.spec.ts
@@ -18,7 +18,7 @@ type Test = {
   valid: boolean;
 };
 
-// This package is indended to be a compatibility mode from v1 JSON Schema.
+// This package is intended to be a compatibility mode from v1 JSON Schema.
 // Some edge cases might not work exactly as specified, but it should work for
 // any real-life schema.
 const skip = new Set<string>([

--- a/openapi-3-1/json-schema-test-suite.spec.ts
+++ b/openapi-3-1/json-schema-test-suite.spec.ts
@@ -19,7 +19,7 @@ type Test = {
   valid: boolean;
 };
 
-// This package is indended to be a compatibility mode from v1 JSON Schema.
+// This package is intended to be a compatibility mode from v1 JSON Schema.
 // Some edge cases might not work exactly as specified, but it should work for
 // any real-life schema.
 const skip = new Set<string>([

--- a/openapi-3-2/json-schema-test-suite.spec.ts
+++ b/openapi-3-2/json-schema-test-suite.spec.ts
@@ -19,7 +19,7 @@ type Test = {
   valid: boolean;
 };
 
-// This package is indended to be a compatibility mode from v1 JSON Schema.
+// This package is intended to be a compatibility mode from v1 JSON Schema.
 // Some edge cases might not work exactly as specified, but it should work for
 // any real-life schema.
 const skip = new Set<string>([


### PR DESCRIPTION
This PR fixes a few minor spelling typos across the codebase:

- Corrects the typo “contraint” → “constraint” in thrown error messages.
- Corrects the typo “indended” → “intended” in JSON Schema test suite comments across multiple files.

These are message-only changes with no behavioral impact, but it 
improves clarity and developer experience.
