### PR TITLE
docs: fix incorrect test watch mode instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,5 +962,5 @@ npm test
 Run the tests with a continuous test runner
 
 ```bash
-npx vitest --watch
+npm test -- --watch
 ```


### PR DESCRIPTION
The README currently suggests running `npm test -- --watch`, but the test script
hard-disables watch mode (`vitest --watch=false`), which causes Vitest to error
due to conflicting `--watch` flags.

This PR updates the documentation to recommend using `npx vitest --watch`
instead, which works correctly without changing existing scripts or CI behavior.

with `npm test -- --watch` 
<img width="1267" height="479" alt="Screenshot 2026-01-10 164526" src="https://github.com/user-attachments/assets/56d31d74-de23-42a6-bd0a-e8413f5e25c6" />

with `npx vitest --watch`
<img width="965" height="810" alt="Screenshot 2026-01-10 165124" src="https://github.com/user-attachments/assets/5dbee870-c0fb-4b2a-af65-35d2ec06640a" />
