### PR TITLE
fix: contains behavior when minContains is 0

### DIFF
--- a/lib/keywords/contains.js
+++ b/lib/keywords/contains.js
@@ -33,7 +33,7 @@ const interpret = ({ contains, minContains, maxContains }, instance, context) =>
     }
     index++;
   }
-  return matches >= minContains && matches <= maxContains;
+  return matches <= maxContains && (minContains === 0 || matches >= minContains);
 };
 
 export default { id, compile, interpret };


### PR DESCRIPTION
Fixes `contains` handling when `minContains` is set to `0`.

Per JSON Schema Validation 2020-12 6.4.5, `minContains: 0` must always pass
validation while still enforcing `maxContains`. This change removes an
incorrect early return and preserves evaluated item annotations.

Spec reference:
https://json-schema.org/draft/2020-12/json-schema-validation.html#name-mincontains

All JSON Schema Test Suite tests pass.

