### PR TITLE
fix: use correct subscription key in publishAsync

### DIFF
--- a/lib/pubsub.js
+++ b/lib/pubsub.js
@@ -16,25 +16,12 @@ export const unsubscribe = (message, token) => {
   delete subscriptions[message][token];
 };
 
-export const publish = (message, data) => {
-  for (const subscribedMessage in subscriptions) {
-    if (subscribedMessage === message || message.startsWith(`${subscribedMessage}.`)) {
-      for (const subscriptionId in subscriptions[subscribedMessage]) {
-        subscriptions[subscribedMessage][subscriptionId](message, data);
-      }
-    }
-  }
-};
-
 export const publishAsync = async (message, data) => {
   const promises = [];
-  for (const subscribedMessage in subscriptions) {
-    if (subscribedMessage === message || message.startsWith(`${subscribedMessage}.`)) {
-      for (const subscriptionId in subscriptions[subscribedMessage]) {
-        promises.push(subscriptions[subscribedMessage][subscriptionId](message, data));
-      }
+  if (message in subscriptions) {
+    for (const subscriptionId in subscriptions[message]) {
+      promises.push(subscriptions[message][subscriptionId](message, data));
     }
   }
-
   await Promise.all(promises);
 };


### PR DESCRIPTION
## Summary
`publishAsync` in `pubsub.js` contained bug where subscriber callbacks were being looked up using the published message key instead of the matched `subscribedMessage` key.

Both `publish` and `publishAsync` iterate over all registered subscription keys and match them against the incoming message using startsWith to support topic prefixes (e.g. a subscriber on "validate" catching "validate.metaValidate"). However, publishAsync incorrectly used subscriptions[message] when invoking the callback instead of subscriptions[subscribedMessage], meaning when the two keys diverged the lookup would target the wrong subscription map returning undefined and throwing a TypeError at runtime.

## Result 
Wildcard subscriptions now work properly with async events without crashing. The async and sync pub/sub implementations now behave the same way.

#### Fixes - #105 