### PR TITLE
add optional `id` to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ import { registerSchema, validate } from "@hyperjump/json-schema/draft-2020-12";
 import { BASIC } from "@hyperjump/json-schema/experimental.js";
 
 class EvaluatedKeywordsPlugin {
+  id = "https://example.com/plugins/evaluated-keywords";
+
   constructor() {
     this.schemaLocations = new Set();
   }
@@ -772,6 +774,7 @@ These are available from the `@hyperjump/json-schema/experimental` export.
     processed to create human readable error messages as needed.
 
 * **EvaluationPlugin**: object
+    * id?: string
     * beforeSchema?(url: string, instance: JsonNode, context: Context): void
     * beforeKeyword?(keywordNode: CompiledSchemaNode, instance: JsonNode, context: Context, schemaContext: Context, keyword: Keyword): void
     * afterKeyword?(keywordNode: CompiledSchemaNode, instance: JsonNode, context: Context, valid: boolean, schemaContext: Context, keyword: Keyword): void

--- a/draft-2020-12/dynamicRef.js
+++ b/draft-2020-12/dynamicRef.js
@@ -24,6 +24,7 @@ const interpret = ([id, fragment, ref], instance, context) => {
 const simpleApplicator = true;
 
 const plugin = {
+  id: `${id}#plugin`,
   beforeSchema(url, _instance, context) {
     context.dynamicAnchors = {
       ...context.ast.metaData[toAbsoluteUri(url)].dynamicAnchors,

--- a/lib/evaluation-plugins/annotations.js
+++ b/lib/evaluation-plugins/annotations.js
@@ -2,6 +2,8 @@ import * as Instance from "../instance.js";
 
 
 export class AnnotationsPlugin {
+  id = "https://json-schema.hyperjump.io/plugins/annotations";
+
   beforeSchema(_url, _instance, context) {
     context.annotations ??= [];
     context.schemaAnnotations = [];

--- a/lib/evaluation-plugins/basic-output.js
+++ b/lib/evaluation-plugins/basic-output.js
@@ -3,6 +3,8 @@ import * as Instance from "../instance.js";
 
 
 export class BasicOutputPlugin {
+  id = "https://json-schema.hyperjump.io/plugins/basic-output";
+
   beforeSchema(_url, _intance, context) {
     context.errors ??= [];
   }

--- a/lib/evaluation-plugins/detailed-output.js
+++ b/lib/evaluation-plugins/detailed-output.js
@@ -3,6 +3,8 @@ import * as Instance from "../instance.js";
 
 
 export class DetailedOutputPlugin {
+  id = "https://json-schema.hyperjump.io/plugins/detailed-output";
+
   beforeSchema(_url, _instance, context) {
     context.errors ??= [];
   }

--- a/lib/experimental.d.ts
+++ b/lib/experimental.d.ts
@@ -88,6 +88,7 @@ export type ValidationContext = {
 
 // Evaluation Plugins
 export type EvaluationPlugin<Context extends ValidationContext = ValidationContext> = {
+  id?: string;
   beforeSchema?(url: string, instance: JsonNode, context: Context): void;
   beforeKeyword?(keywordNode: Node<unknown>, instance: JsonNode, context: Context, schemaContext: Context, keyword: Keyword<unknown>): void;
   afterKeyword?(keywordNode: Node<unknown>, instance: JsonNode, context: Context, valid: boolean, schemaContext: Context, keyword: Keyword<unknown>): void;
@@ -95,6 +96,7 @@ export type EvaluationPlugin<Context extends ValidationContext = ValidationConte
 };
 
 export class BasicOutputPlugin implements EvaluationPlugin<ErrorsContext> {
+  id: string;
   errors: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: ErrorsContext): void;
@@ -104,6 +106,7 @@ export class BasicOutputPlugin implements EvaluationPlugin<ErrorsContext> {
 }
 
 export class DetailedOutputPlugin implements EvaluationPlugin<ErrorsContext> {
+  id: string;
   errors: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: ErrorsContext): void;
@@ -117,6 +120,7 @@ export type ErrorsContext = ValidationContext & {
 };
 
 export class AnnotationsPlugin implements EvaluationPlugin<AnnotationsContext> {
+  id: string;
   annotations: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: AnnotationsContext): void;

--- a/lib/keywords/dynamicRef.js
+++ b/lib/keywords/dynamicRef.js
@@ -23,6 +23,7 @@ const interpret = (fragment, instance, context) => {
 const simpleApplicator = true;
 
 const plugin = {
+  id: `${id}#plugin`,
   beforeSchema(url, _instance, context) {
     context.dynamicAnchors = {
       ...context.ast.metaData[toAbsoluteUri(url)].dynamicAnchors,

--- a/lib/keywords/unevaluatedItems.js
+++ b/lib/keywords/unevaluatedItems.js
@@ -33,6 +33,7 @@ const interpret = (unevaluatedItems, instance, context) => {
 const simpleApplicator = true;
 
 const plugin = {
+  id: `${id}#plugin`,
   beforeSchema(_url, instance, context) {
     context.evaluatedItems ??= new Set();
     context.schemaEvaluatedItems = new Set();

--- a/lib/keywords/unevaluatedProperties.js
+++ b/lib/keywords/unevaluatedProperties.js
@@ -33,6 +33,7 @@ const interpret = (unevaluatedProperties, instance, context) => {
 const simpleApplicator = true;
 
 const plugin = {
+  id: `${id}#plugin`,
   beforeSchema(_url, instance, context) {
     context.evaluatedProperties ??= new Set();
     context.schemaEvaluatedProperties = new Set();


### PR DESCRIPTION
## Description
This PR makes `EvaluationPlugin` instances JSON-serializable by introducing an optional `id` identifier.

Solves : #110 

### Changes Made
1. **Types & Base Plugins**: 
   - Updated the `EvaluationPlugin` interface in `lib/experimental.d.ts` to include an optional `id?: string` property.
   - Added  `id` properties to the `BasicOutputPlugin`, `DetailedOutputPlugin`, and `AnnotationsPlugin` class declarations.
   - Updated `README.md` to reflect the new `id` field in the `EvaluationPlugin` documentation.
2. **Keyword-Specific Plugins**: 
   - Added an `id` property to the plugins defined in the `dynamicRef`, `unevaluatedProperties`, and `unevaluatedItems` keyword handlers.
   - Added an `id` property to the `draft-2020-12/dynamicRef` keyword handler.
  