### PR TITLE
add high-level validator serialization API

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -13,6 +13,7 @@ import { getKeywordName } from "./keywords.js";
 import Validation from "./keywords/validation.js";
 import { BasicOutputPlugin } from "./evaluation-plugins/basic-output.js";
 import { DetailedOutputPlugin } from "./evaluation-plugins/detailed-output.js";
+import { serialize, deserialize } from "./compiled-schema-serialization.js";
 
 
 export const FLAG = "FLAG", BASIC = "BASIC", DETAILED = "DETAILED";
@@ -22,8 +23,17 @@ export const validate = async (url, value = undefined, options = undefined) => {
   const schema = await getSchema(url);
   const compiled = await compile(schema);
   const interpretAst = (value, options) => interpret(compiled, Instance.fromJs(value), options);
+  interpretAst.serialize = () => serialize(compiled);
 
   return value === undefined ? interpretAst : interpretAst(value, options);
+};
+
+export const restoreValidator = (json) => {
+  const compiled = deserialize(json);
+  const interpretAst = (value, options) => interpret(compiled, Instance.fromJs(value), options);
+  interpretAst.serialize = () => serialize(compiled);
+
+  return interpretAst;
 };
 
 export const compile = async (schema) => {

--- a/lib/experimental.d.ts
+++ b/lib/experimental.d.ts
@@ -17,9 +17,12 @@ export type CompiledSchema = {
   ast: AST;
 };
 
+export const serialize: (compiledSchema: CompiledSchema) => string;
+export const deserialize: (serialized: string) => CompiledSchema;
+
 type AST = {
   metaData: Record<string, MetaData>;
-  plugins: EvaluationPlugin[];
+  plugins: Set<EvaluationPlugin>;
 } & Record<string, Node<unknown>[] | boolean>;
 
 type Node<A> = [keywordId: string, schemaUri: string, keywordValue: A];
@@ -88,6 +91,7 @@ export type ValidationContext = {
 
 // Evaluation Plugins
 export type EvaluationPlugin<Context extends ValidationContext = ValidationContext> = {
+  id?: string;
   beforeSchema?(url: string, instance: JsonNode, context: Context): void;
   beforeKeyword?(keywordNode: Node<unknown>, instance: JsonNode, context: Context, schemaContext: Context, keyword: Keyword<unknown>): void;
   afterKeyword?(keywordNode: Node<unknown>, instance: JsonNode, context: Context, valid: boolean, schemaContext: Context, keyword: Keyword<unknown>): void;
@@ -95,6 +99,7 @@ export type EvaluationPlugin<Context extends ValidationContext = ValidationConte
 };
 
 export class BasicOutputPlugin implements EvaluationPlugin<ErrorsContext> {
+  id: string;
   errors: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: ErrorsContext): void;
@@ -104,6 +109,7 @@ export class BasicOutputPlugin implements EvaluationPlugin<ErrorsContext> {
 }
 
 export class DetailedOutputPlugin implements EvaluationPlugin<ErrorsContext> {
+  id: string;
   errors: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: ErrorsContext): void;
@@ -117,6 +123,7 @@ export type ErrorsContext = ValidationContext & {
 };
 
 export class AnnotationsPlugin implements EvaluationPlugin<AnnotationsContext> {
+  id: string;
   annotations: OutputUnit[];
 
   beforeSchema(url: string, instance: JsonNode, context: AnnotationsContext): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,7 +28,12 @@ export const validate: (
   (url: string) => Promise<Validator>
 );
 
-export type Validator = (value: Json, options?: OutputFormat | ValidationOptions) => Output;
+export const restoreValidator: (json: string) => Validator;
+
+export type Validator = {
+  (value: Json, options?: OutputFormat | ValidationOptions): Output;
+  serialize(): string;
+};
 
 export type Output = {
   valid: true;

--- a/lib/restore-validator.spec.ts
+++ b/lib/restore-validator.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { registerSchema, validate, restoreValidator } from "../v1/index.js";
+
+
+describe("Validator Serialization for high-level API", () => {
+  const schemaUri = "schema:high-level-serialization";
+  const dialectUri = "https://json-schema.org/v1";
+
+  test("serializes and restores a validator successfully", async () => {
+    registerSchema({
+      type: "object",
+      properties: {
+        foo: { type: "string", pattern: "^[a-z]+$" },
+        bar: { type: "number", minimum: 10 }
+      },
+      required: ["foo"]
+    }, schemaUri, dialectUri);
+
+    const originalValidator = await validate(schemaUri);
+
+    expect(originalValidator({ foo: "abc", bar: 42 }).valid).toBe(true);
+    expect(originalValidator({ foo: "123" }).valid).toBe(false);
+
+    const json = originalValidator.serialize();
+    expect(typeof json).toBe("string");
+
+    const restoredValidator = restoreValidator(json);
+
+    expect(restoredValidator({ foo: "abc", bar: 42 }).valid).toBe(true);
+    expect(restoredValidator({ foo: "123" }).valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Resolves #112

This PR introduces a first-class, high-level API for validator serialization, allowing users to cleanly serialize and restore validators without interacting directly with the low-level AST.

**Changes included:**
*   Attached a `.serialize()` method directly to the validator function returned by `validate()`.
*   Added a new `restoreValidator(json)` API that deserializes the AST and reconstructs the validator by resolving its evaluation plugins.
*   Cleaned up function signatures by removing the obsolete `DeserializeOptions` type and `options` parameters, as `pluginsById` is no longer required with the new  approach.
*   Added a  test suite (`lib/restore-validator.spec.ts`) to ensure the high-level API behaves correctly.
