### PR TITLE
fix: avoid trailing comma in jsonStringify when replacer skips last property

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -126,15 +126,16 @@ const stringifyObject = (value, replacer, space, pointer, depth) => {
   const colonSpacing = space ? " " : "";
 
   let result = "{" + padding + space;
-  for (let index = 0; index < entries.length; index++) {
-    const [key, value] = entries[index];
+  let first = true;
+  for (const [key, value] of entries) {
     const keyPointer = JsonPointer.append(key, pointer);
     const stringifiedValue = stringifyValue(value, replacer, space, key, keyPointer, depth + 1);
     if (stringifiedValue !== undefined) {
-      result += JSON.stringify(key) + ":" + colonSpacing + stringifiedValue;
-      if (entries[index + 1]) {
+      if (!first) {
         result += `,${padding}${space}`;
       }
+      first = false;
+      result += JSON.stringify(key) + ":" + colonSpacing + stringifiedValue;
     }
   }
   return result + padding + "}";

--- a/lib/stringify.spec.ts
+++ b/lib/stringify.spec.ts
@@ -39,6 +39,20 @@ describe("Json.stringify", () => {
       expect(jsonStringify(value, replacer)).to.eql(JSON.stringify(value, replacer));
     });
 
+    it("should remove the last property when it returns undefined without leaving a trailing comma", () => {
+      const value = {
+        aaa: "foo",
+        bbb: "bar"
+      };
+      const replacer = (key: string, value: unknown) => {
+        if (key !== "bbb") {
+          return value;
+        }
+      };
+
+      expect(jsonStringify(value, replacer)).to.eql(JSON.stringify(value, replacer));
+    });
+
     it("should remove items that return undefined", () => {
       const value = ["foo", "bar"];
       const replacer = (key: string, value: unknown) => {


### PR DESCRIPTION
### Description

This PR fixes a bug in `jsonStringify` where omitting the last property of an object via a custom replacer function resulted in a trailing comma (producing invalid JSON, e.g. `{"aaa":"foo",}`).

Instead of using the raw entries index (`entries[index + 1]`) to append commas (which doesn't account for properties that get filtered out by the replacer), `stringifyObject` now dynamically prepends commas before writing any subsequent non-undefined property.

#### Key Changes:
- **`lib/common.js`**: Refactored `stringifyObject` to dynamically prefix commas and converted the loop to a modern `for-of` loop to satisfy the project's `@typescript-eslint/prefer-for-of` linting rule.
- **`lib/stringify.spec.ts`**: Added a dedicated unit test case validating that omitting the last property produces correct, valid JSON without a trailing comma.

### Related Issues
Closes #119 
