### PR TITLE
fix: correct non-transitive keywordComparator in validation.js

### DIFF
--- a/lib/keywords/validation.js
+++ b/lib/keywords/validation.js
@@ -56,7 +56,7 @@ const lastKeywords = new Set([
   "https://json-schema.org/keyword/unevaluatedProperties",
   "https://json-schema.org/keyword/unevaluatedItems"
 ]);
-const keywordComparator = (_a, b) => lastKeywords.has(b[0]) ? -1 : 1;
+const keywordComparator = (a, b) => lastKeywords.has(a[0]) - lastKeywords.has(b[0]);
 
 const interpret = (url, instance, context) => {
   let valid = true;


### PR DESCRIPTION
### Problem
In `lib/keywords/validation.js`, the `keywordComparator` is used to sort compiled keywords so that `unevaluatedProperties` and `unevaluatedItems` are evaluated last.

The previous comparator was defined as:
```js
const keywordComparator = (_a, b) => lastKeywords.has(b[0]) ? -1 : 1;
```
This comparator violates the `Array.prototype.sort()` contract:

1. It never returns `0` (which signifies equal sorting priority).
2. It is non-transitive and contradictory (e.g., comparing two normal keywords `A` and `B` results in `A > B` and `B > A` simultaneously).

Because of this, the sorting behavior becomes non-deterministic and engine-dependent. Depending on the JS engine (V8, SpiderMonkey, JSC) or array size, `unevaluatedProperties/unevaluatedItems` could fail to sort to the end, causing unexpected validation bugs.

### Solution
Refactored the comparator to correctly compare both inputs and respect the sort contract:

```js
const keywordComparator = (a, b) => {
  const isA = lastKeywords.has(a[0]);
  const isB = lastKeywords.has(b[0]);
  return isA === isB ? 0 : isA ? 1 : -1;
};
```
This ensures that:

- Two keywords of the same priority return 0 (stable sorting).
- A keyword that belongs at the end returns 1 when compared to a normal one.
- A keyword that belongs at the end returns -1 when compared from the other side.